### PR TITLE
Add Create Habit tab and update home header

### DIFF
--- a/app/navigators/app-navigator.tsx
+++ b/app/navigators/app-navigator.tsx
@@ -103,6 +103,8 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
               iconName = focused ? "home-filled" : "home"
             } else if (route.name === "Statistics") {
               iconName = focused ? "data-usage" : "data-usage"
+            } else if (route.name === "CreateHabit") {
+              iconName = focused ? "add-circle" : "add-circle-outline"
             } else if (route.name === "SettingsStack") {
               iconName = focused ? "settings" : "settings"
             }
@@ -125,6 +127,7 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
         
         {<Tab.Screen name="Statistics" component={Screens.StatisticsScreen} />}
         <Tab.Screen name="HomeStack" component={HomeStack} />
+        <Tab.Screen name="CreateHabit" component={Screens.CreateHabitScreen} />
         {<Tab.Screen name="SettingsStack" component={SettingsStack} />}
       </Tab.Navigator>
     </NavigationContainer>

--- a/app/navigators/types.ts
+++ b/app/navigators/types.ts
@@ -27,6 +27,7 @@ export type SettingsStackParamList = {
 export type TabParamList = {
   HomeStack: NavigatorScreenParams<HomeStackParamList>
   Statistics: undefined
+  CreateHabit: undefined
   SettingsStack: NavigatorScreenParams<SettingsStackParamList>
 }
 

--- a/app/screens/home.tsx
+++ b/app/screens/home.tsx
@@ -60,14 +60,6 @@ export const HomeScreen: FC<HomeScreenProps> = observer(function HomeScreen({ na
           <TouchableOpacity onPress={() => navigation.navigate("Calendar")}>
             <MaterialCommunityIcons name="calendar-month-outline" size={28} color={colors.text} />
           </TouchableOpacity>
-          <View style={{ backgroundColor: colors.palette.primary600, width: 40, height: 40, alignItems: "center", justifyContent: "center", borderRadius: 99 }}>
-            <MaterialCommunityIcons
-              name="plus"
-              color={colors.palette.neutral100}
-              size={28}
-              onPress={() => navigation.navigate("CreateHabit")}
-            />
-          </View>
         </View>
 
         <View style={{ flexDirection: "row", gap: 18 }}>


### PR DESCRIPTION
## Summary
- Replace top-right new-habit button with calendar in Home screen
- Add "CreateHabit" tab beside existing bottom navigation items
- Extend navigation types for new tab route

## Testing
- `npm test`
- `npm run compile` *(fails: Option 'customConditions' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler')*
- `npm run lint` *(fails: react-native/no-inline-styles, @typescript-eslint/no-unused-vars, react-native/no-color-literals)*

------
https://chatgpt.com/codex/tasks/task_e_689aad1e30fc8331b47fcc87ef36d2c4