### PR TITLE
refactor habit store persistence with string helpers

### DIFF
--- a/app/models/helpers/persistHabitStore.test.ts
+++ b/app/models/helpers/persistHabitStore.test.ts
@@ -1,0 +1,44 @@
+import { getSnapshot } from "mobx-state-tree"
+import * as storage from "../../utils/storage"
+
+jest.mock("../../utils/storage")
+jest.mock("uuid", () => ({ v4: () => "test-id" }))
+
+const { HabitStore } = require("../HabitStore")
+const { persistHabitStore } = require("./persistHabitStore")
+
+const STORAGE_KEY = "habit-store"
+
+const sampleSnapshot = {
+  habits: [],
+  checkIns: [],
+}
+
+test("loads snapshot on start and saves on change", async () => {
+  (storage.loadString as jest.Mock).mockResolvedValue(JSON.stringify(sampleSnapshot))
+  const saveStringMock = storage.saveString as jest.Mock
+
+  const store = HabitStore.create({ habits: [], checkIns: [] })
+  persistHabitStore(store)
+
+  await Promise.resolve()
+
+  expect(getSnapshot(store)).toEqual(sampleSnapshot)
+
+  store.addHabit({
+    emoji: "🔥",
+    name: "Test",
+    time: "10:00",
+    finished: false,
+    repeatDays: [],
+    dailyTarget: 1,
+    progress: 0,
+    lastUpdated: "",
+  })
+
+  const updatedSnapshot = getSnapshot(store)
+  expect(saveStringMock).toHaveBeenLastCalledWith(
+    STORAGE_KEY,
+    JSON.stringify(updatedSnapshot),
+  )
+})

--- a/app/models/helpers/persistHabitStore.ts
+++ b/app/models/helpers/persistHabitStore.ts
@@ -1,46 +1,27 @@
 import { onSnapshot, applySnapshot } from "mobx-state-tree"
 import { HabitStore } from "../HabitStore"
-//import { storage } from "../../utils/storage/mmkv"
 import * as storage from "../../utils/storage"
 
 const STORAGE_KEY = "habit-store"
 
 export function persistHabitStore(storeInstance: typeof HabitStore.Type) {
-  /*const saved = storage.getString(STORAGE_KEY)
-  if (saved) {
-    try {
-      applySnapshot(storeInstance, JSON.parse(saved))
-    } catch (err) {
-      console.error("❌ Error loading habitStore snapshot", err)
-    }
-  }
-
-  onSnapshot(storeInstance, (snapshot) => {
-    try {
-      storage.set(STORAGE_KEY, JSON.stringify(snapshot))
-    } catch (err) {
-      console.error("❌ Error saving habitStore snapshot", err)
-    }
-  })
-    */
-  storage.load(STORAGE_KEY).then((saved) => {
-    if (typeof saved === "string") {
+  storage.loadString(STORAGE_KEY).then((saved) => {
+    if (saved) {
       try {
         applySnapshot(storeInstance, JSON.parse(saved))
       } catch (err) {
         console.error("❌ Error loading habitStore snapshot", err)
       }
     } else {
-      console.warn("⚠️ No saved habitStore snapshot found or not a string.")
+      console.warn("⚠️ No saved habitStore snapshot found.")
     }
-  })  
-  
+  })
+
   onSnapshot(storeInstance, (snapshot) => {
     try {
-      storage.save(STORAGE_KEY, JSON.stringify(snapshot))
+      storage.saveString(STORAGE_KEY, JSON.stringify(snapshot))
     } catch (err) {
       console.error("❌ Error saving habitStore snapshot", err)
     }
   })
-  
 }


### PR DESCRIPTION
## Summary
- switch habit store persistence to `loadString`/`saveString` and handle JSON directly
- add unit test verifying load/save round-trip for habit store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bdad8f0688331910524d180453cb9