### PR TITLE
Remove redundant notification handler from habit creation screen

### DIFF
--- a/app/screens/create-habit.tsx
+++ b/app/screens/create-habit.tsx
@@ -1,6 +1,6 @@
 // 🔥 CLEANED + FIXED create-habit.tsx FILE
 
-import React, { useState, useEffect } from "react"
+import React, { useState } from "react"
 import { observer } from "mobx-react-lite"
 import {
   View,
@@ -49,17 +49,7 @@ export const CreateHabitScreen = observer(function CreateHabitScreen() {
     setEditingTimeIndex(null)
   }
 
-  useEffect(() => {
-    Notifications.setNotificationHandler({
-      handleNotification: async () => ({
-        shouldShowAlert: true,
-        shouldPlaySound: true,
-        shouldSetBadge: false,
-        shouldShowBanner: true,
-        shouldShowList: true,
-      }),
-    })
-  }, [])
+
 
   const requestNotificationPermission = async () => {
     const { status } = await Notifications.requestPermissionsAsync()


### PR DESCRIPTION
## Summary
- remove per-screen Notifications.setNotificationHandler setup
- rely on App-level configuration for notification handler

## Testing
- `npm test`
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bdad9b4cc8331ac30a6fdb31f0276