### PR TITLE
chore: clarify notification permission

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,7 +45,7 @@
       },
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
-        "NSUserNotificationUsageDescription": "Reason for sending reminders"
+        "NSUserNotificationUsageDescription": "We send reminders so you never miss a habit."
       }
     },
     "web": {


### PR DESCRIPTION
## Summary
- clarify iOS notification permission text

## Testing
- `npm test`
- `npm run prebuild:clean`
- `npm run ios` *(fails: iOS apps can only be built on macOS devices)*

------
https://chatgpt.com/codex/tasks/task_e_689bdadc285883318ed114ab038303c3