### PR TITLE
chore: guard console logs

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -72,8 +72,8 @@ function App(props: AppProps) {
     const { rehydrated, rootStore } = useInitialRootStore(() => {
       persistHabitStore(rootStore.habitStore)
       syncNotifications(rootStore.habitStore)
-    
-      console.log("✅ RootStore ready. Hiding splash in 500ms")
+
+      if (__DEV__) console.log("✅ RootStore ready. Hiding splash in 500ms")
       setTimeout(hideSplashScreen, 500)
     
       if (Platform.OS === "android") {

--- a/app/screens/edit-habit.tsx
+++ b/app/screens/edit-habit.tsx
@@ -25,7 +25,7 @@ export const EditHabitScreen = observer(function EditHabitScreen() {
 
   const habit = habitStore.habits.find((h) => h.id === habitId)
 
-  console.log("🛠 Editing Habit ID:", habitId, "| Habit Found:", !!habit)
+  if (__DEV__) console.log("🛠 Editing Habit ID:", habitId, "| Habit Found:", !!habit)
 
   const [name, setName] = useState("")
   const [emoji, setEmoji] = useState("")
@@ -64,7 +64,7 @@ export const EditHabitScreen = observer(function EditHabitScreen() {
       } as unknown as Notifications.NotificationTriggerInput,
     })
 
-    console.log("✅ Updating Habit:", habit.id)
+    if (__DEV__) console.log("✅ Updating Habit:", habit.id)
 
     habitStore.updateHabit({
       id: habit.id,

--- a/app/screens/settings.tsx
+++ b/app/screens/settings.tsx
@@ -133,7 +133,9 @@ export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
           <Link
             icon="logout"
             title="Logout"
-            handleClick={() => console.log("logout")}
+            handleClick={() => {
+              if (__DEV__) console.log("logout")
+            }}
             length={1}
             index={0}
           />

--- a/app/utils/syncNotifications.ts
+++ b/app/utils/syncNotifications.ts
@@ -10,5 +10,7 @@ export async function syncNotifications(habitStore: typeof HabitStore.Type) {
     await Notifications.cancelScheduledNotificationAsync(orphan.identifier)
   }
 
-  console.log(`🧹 Removed ${orphans.length} orphaned notifications`)
+  if (__DEV__) {
+    console.log(`🧹 Removed ${orphans.length} orphaned notifications`)
+  }
 }


### PR DESCRIPTION
## Summary
- guard root store init log for dev only
- protect misc debugging logs with dev flag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bdaddd46c8331a16b6e3d3c984989