### PR TITLE
Clamp habit progress when lowering daily target

### DIFF
--- a/app/models/HabitStore.ts
+++ b/app/models/HabitStore.ts
@@ -125,6 +125,10 @@ export const HabitStore = types
       habit.repeatDays.replace(updatedHabit.repeatDays)
       habit.dailyTarget = updatedHabit.dailyTarget
 
+      if (habit.progress > habit.dailyTarget) {
+        habit.progress = habit.dailyTarget
+      }
+
       if (updatedHabit.notificationIds) {
         habit.notificationIds.replace(updatedHabit.notificationIds)
       }

--- a/test/update-habit-progress.test.ts
+++ b/test/update-habit-progress.test.ts
@@ -1,0 +1,41 @@
+import * as Notifications from "expo-notifications"
+import { HabitStore } from "../app/models/HabitStore"
+
+jest.mock("expo-notifications", () => ({
+  cancelScheduledNotificationAsync: jest.fn(),
+}))
+jest.mock("uuid", () => ({ v4: jest.fn() }))
+
+describe("HabitStore.updateHabit", () => {
+  it("clamps progress when dailyTarget decreases", () => {
+    const habitStore = HabitStore.create({
+      habits: [
+        {
+          id: "1",
+          emoji: "🔥",
+          name: "Test",
+          time: null,
+          finished: false,
+          repeatDays: [],
+          dailyTarget: 10,
+          progress: 10,
+          lastUpdated: "2021-01-01",
+          notificationIds: [],
+        },
+      ],
+    })
+
+    habitStore.updateHabit({
+      id: "1",
+      name: "Test",
+      emoji: "🔥",
+      time: null,
+      repeatDays: [],
+      dailyTarget: 5,
+    })
+
+    const habit = habitStore.habits[0]
+    expect(habit.dailyTarget).toBe(5)
+    expect(habit.progress).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- ensure habit progress never exceeds new daily target when editing
- add regression test for progress clamping

## Testing
- `npm test`
- `npm run lint` *(fails: 83 errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689bf88019308331833ee892317201ee