### PR TITLE
feat: daily target stepper and theme

### DIFF
--- a/app/screens/create-habit.tsx
+++ b/app/screens/create-habit.tsx
@@ -20,6 +20,7 @@ import DateTimePicker from "@react-native-community/datetimepicker"
 import Toast from "react-native-toast-message"
 import * as Notifications from "expo-notifications"
 import EmojiPicker from "rn-emoji-keyboard"
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons"
 
 export const CreateHabitScreen = observer(function CreateHabitScreen() {
   const { habitStore } = useStores()
@@ -31,7 +32,7 @@ export const CreateHabitScreen = observer(function CreateHabitScreen() {
   const [tempTime, setTempTime] = useState(new Date())
   const [showTimeModal, setShowTimeModal] = useState(false)
   const [repeatDays, setRepeatDays] = useState<string[]>([])
-  const [dailyTarget, setDailyTarget] = useState("1")
+  const [dailyTarget, setDailyTarget] = useState(1)
   const [notificationEnabled, setNotificationEnabled] = useState(false)
   const [notificationTimes, setNotificationTimes] = useState<Date[]>([])
   const [editingTimeIndex, setEditingTimeIndex] = useState<number | null>(null)
@@ -43,7 +44,7 @@ export const CreateHabitScreen = observer(function CreateHabitScreen() {
     setTempTime(new Date())
     setShowTimeModal(false)
     setRepeatDays([])
-    setDailyTarget("1")
+    setDailyTarget(1)
     setNotificationEnabled(false)
     setNotificationTimes([])
     setEditingTimeIndex(null)
@@ -75,6 +76,9 @@ export const CreateHabitScreen = observer(function CreateHabitScreen() {
       setRepeatDays([...repeatDays, day])
     }
   }
+
+  const incrementTarget = () => setDailyTarget((prev) => Math.min(prev + 1, 99))
+  const decrementTarget = () => setDailyTarget((prev) => Math.max(prev - 1, 1))
 
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
@@ -118,7 +122,7 @@ export const CreateHabitScreen = observer(function CreateHabitScreen() {
       time: notificationTimes.length > 0 ? formatTime(notificationTimes[0]) : null,
       finished: false,
       repeatDays,
-      dailyTarget: parseInt(dailyTarget),
+      dailyTarget,
       notificationIds,
     })
 
@@ -335,31 +339,15 @@ export const CreateHabitScreen = observer(function CreateHabitScreen() {
 
       <View style={{ marginBottom: spacing.lg, alignSelf: "flex-start" }}>
         <Text text="How many times per day?" />
-        <TextInput
-          value={dailyTarget}
-          onChangeText={(text) => {
-            const numeric = text.replace(/[^0-9]/g, "")
-            if (numeric === "") {
-              setDailyTarget("")
-              return
-            }
-            const clamped = Math.max(1, Math.min(99, parseInt(numeric)))
-            setDailyTarget(clamped.toString())
-          }}
-          keyboardType="numeric"
-          maxLength={2}
-          placeholder="e.g. 1"
-          style={{
-            width: 80,
-            borderColor: colors.border,
-            borderWidth: 1,
-            borderRadius: 8,
-            padding: 10,
-            marginTop: spacing.xs,
-            color: colors.text,
-            textAlign: "center",
-          }}
-        />
+        <View style={{ flexDirection: "row", alignItems: "center", marginTop: spacing.xs, gap: spacing.md }}>
+          <TouchableOpacity onPress={decrementTarget}>
+            <MaterialCommunityIcons name="minus-circle-outline" size={24} color={colors.text} />
+          </TouchableOpacity>
+          <Text text={dailyTarget.toString()} style={{ color: colors.text }} />
+          <TouchableOpacity onPress={incrementTarget}>
+            <MaterialCommunityIcons name="plus-circle-outline" size={24} color={colors.text} />
+          </TouchableOpacity>
+        </View>
       </View>
 
       <TouchableOpacity

--- a/app/theme/colors.ts
+++ b/app/theme/colors.ts
@@ -1,6 +1,8 @@
 // TODO: write documentation for colors and palette in own markdown file and add links from here
 
-const palette = {
+import { Appearance } from "react-native"
+
+const lightPalette = {
   neutral100: "#FFFFFF",
   neutral200: "#F4F2F1",
   neutral300: "#D7CEC9",
@@ -39,6 +41,48 @@ const palette = {
   overlay50: "rgba(25, 16, 21, 0.5)",
 } as const
 
+const darkPalette = {
+  neutral100: "#000000",
+  neutral200: "#191015",
+  neutral300: "#3C3836",
+  neutral400: "#564E4A",
+  neutral500: "#978F8A",
+  neutral600: "#B6ACA6",
+  neutral700: "#D7CEC9",
+  neutral800: "#F4F2F1",
+  neutral900: "#FFFFFF",
+
+  primary100: "#F4E0D9",
+  primary200: "#E8C1B4",
+  primary300: "#DDA28E",
+  primary400: "#D28468",
+  primary500: "#C76542",
+  primary600: "#A54F31",
+
+  secondary100: "#DCDDE9",
+  secondary200: "#BCC0D6",
+  secondary300: "#9196B9",
+  secondary400: "#626894",
+  secondary500: "#41476E",
+
+  accent100: "#FFEED4",
+  accent200: "#FFE1B2",
+  accent300: "#FDD495",
+  accent400: "#FBC878",
+  accent500: "#FFBB50",
+
+  angry100: "#F2D6CD",
+  angry500: "#C03403",
+
+  success: "#56C568",
+
+  overlay20: "rgba(25, 16, 21, 0.2)",
+  overlay50: "rgba(25, 16, 21, 0.5)",
+} as const
+
+const colorScheme = Appearance.getColorScheme() ?? "light"
+const palette = colorScheme === "dark" ? darkPalette : lightPalette
+
 export const colors = {
   /**
    * The palette is available to use, but prefer using the name.
@@ -53,19 +97,19 @@ export const colors = {
   /**
    * The default text color in many components.
    */
-  text: palette.neutral800,
+  text: colorScheme === "dark" ? palette.neutral900 : palette.neutral800,
   /**
    * Secondary text information.
    */
-  textDim: palette.neutral600,
+  textDim: colorScheme === "dark" ? palette.neutral700 : palette.neutral600,
   /**
    * The default color of the screen background.
    */
-  background: palette.neutral200,
+  background: colorScheme === "dark" ? palette.neutral100 : palette.neutral200,
   /**
    * The default border color.
    */
-  border: palette.neutral400,
+  border: colorScheme === "dark" ? palette.neutral300 : palette.neutral400,
   /**
    * The main tinting color.
    */
@@ -73,14 +117,13 @@ export const colors = {
   /**
    * A subtle color used for lines.
    */
-  separator: palette.neutral300,
+  separator: colorScheme === "dark" ? palette.neutral300 : palette.neutral300,
   /**
    * Error messages.
    */
   error: palette.angry500,
   /**
    * Error Background.
-   *
    */
   errorBackground: palette.angry100,
   /**


### PR DESCRIPTION
## Summary
- replace daily target input with +/- stepper in Create Habit
- implement dynamic light/dark color palettes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a241aa8e9883319dfabe07c2358e7d