### PR TITLE
feat: add manual dark mode toggle

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -6,6 +6,7 @@ import "./i18n"
 import "./utils/ignoreWarnings"
 import { useFonts } from "expo-font"
 import React, { useEffect } from "react"
+import { observer } from "mobx-react-lite"
 import { initialWindowMetrics, SafeAreaProvider } from "react-native-safe-area-context"
 import * as Linking from "expo-linking"
 import { useInitialRootStore, useStores } from "./models"
@@ -19,6 +20,7 @@ import Toast from "react-native-toast-message"
 import * as Notifications from "expo-notifications"
 import { persistHabitStore } from "app/models/helpers/persistHabitStore"
 import { syncNotifications } from "app/utils/syncNotifications"
+import { setColorScheme } from "./theme/colors"
 
 export const NAVIGATION_PERSISTENCE_KEY = "NAVIGATION_STATE"
 
@@ -42,7 +44,7 @@ interface AppProps {
   hideSplashScreen: () => Promise<boolean>
 }
 
-function App(props: AppProps) {
+const App = observer(function App(props: AppProps) {
   const { hideSplashScreen } = props
 
   const {
@@ -53,7 +55,7 @@ function App(props: AppProps) {
 
   const [areFontsLoaded] = useFonts(customFontsToLoad)
 
-  /*const { rehydrated } = useInitialRootStore(() => {
+  /* const { rehydrated } = useInitialRootStore(() => {
     const { habitStore } = useStores()
 
     persistHabitStore(habitStore)
@@ -68,7 +70,7 @@ function App(props: AppProps) {
         sound: "default",
       })
     }
-  })*/
+  }) */
     const { rehydrated, rootStore } = useInitialRootStore(() => {
       persistHabitStore(rootStore.habitStore)
       syncNotifications(rootStore.habitStore)
@@ -84,7 +86,12 @@ function App(props: AppProps) {
         })
       }
     })
-    
+
+  const { settingsStore } = useStores()
+
+  useEffect(() => {
+    setColorScheme(settingsStore.isDarkMode ? "dark" : "light")
+  }, [settingsStore.isDarkMode])
 
   useEffect(() => {
     Notifications.setNotificationHandler({
@@ -117,7 +124,7 @@ function App(props: AppProps) {
       </ErrorBoundary>
     </SafeAreaProvider>
   )
-}
+})
 
 export default App
 

--- a/app/models/RootStore.ts
+++ b/app/models/RootStore.ts
@@ -1,11 +1,13 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
 import { HabitStore } from "./HabitStore"
+import { SettingsStore } from "./SettingsStore"
 
 /**
  * A RootStore model.
  */
 export const RootStoreModel = types.model("RootStore", {
   habitStore: types.optional(HabitStore, {} as any), // ✅ Allows booting from nothing
+  settingsStore: types.optional(SettingsStore, {} as any),
 })
 
 /**

--- a/app/models/SettingsStore.ts
+++ b/app/models/SettingsStore.ts
@@ -1,0 +1,20 @@
+import { types } from "mobx-state-tree"
+
+export const SettingsStoreModel = types
+  .model("SettingsStore", {
+    /** Controls whether the application uses the dark color scheme */
+    isDarkMode: types.optional(types.boolean, false),
+  })
+  .actions((store) => ({
+    /** Enable or disable dark mode */
+    setDarkMode(value: boolean) {
+      store.isDarkMode = value
+    },
+    /** Convenience toggle */
+    toggleDarkMode() {
+      store.isDarkMode = !store.isDarkMode
+    },
+  }))
+
+export const SettingsStore = SettingsStoreModel
+export type SettingsStoreType = typeof SettingsStore.Type

--- a/app/models/helpers/persistSettingsStore.ts
+++ b/app/models/helpers/persistSettingsStore.ts
@@ -1,0 +1,27 @@
+import { onSnapshot, applySnapshot } from "mobx-state-tree"
+import { SettingsStore } from "../SettingsStore"
+import * as storage from "../../utils/storage"
+
+const STORAGE_KEY = "settings-store"
+
+export function persistSettingsStore(storeInstance: typeof SettingsStore.Type) {
+  storage.loadString(STORAGE_KEY).then((raw) => {
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw)
+        applySnapshot(storeInstance, parsed)
+      } catch (err) {
+        console.error("❌ Error loading settingsStore snapshot", err)
+        storage.remove(STORAGE_KEY)
+      }
+    }
+  })
+
+  onSnapshot(storeInstance, (snapshot) => {
+    try {
+      storage.saveString(STORAGE_KEY, JSON.stringify(snapshot))
+    } catch (err) {
+      console.error("❌ Error saving settingsStore snapshot", err)
+    }
+  })
+}

--- a/app/models/helpers/setupRootStore.ts
+++ b/app/models/helpers/setupRootStore.ts
@@ -3,9 +3,10 @@
  */
 import { applySnapshot } from "mobx-state-tree"
 import { RootStore, RootStoreSnapshot, RootStoreModel } from "../RootStore"
-//import { storage } from "../../utils/storage/mmkv"
+// import { storage } from "../../utils/storage/mmkv"
 import * as storage from "../../utils/storage"
 import { persistHabitStore } from "./persistHabitStore"
+import { persistSettingsStore } from "./persistSettingsStore"
 import { syncNotifications } from "app/utils/syncNotifications"
 
 const ROOT_STATE_STORAGE_KEY = "root-v1"
@@ -21,16 +22,19 @@ export async function setupRootStore(): Promise<{
       habits: [],
       checkIns: [],
     },
+    settingsStore: {
+      isDarkMode: false,
+    },
   })
 
   let restoredState: RootStoreSnapshot | undefined
 
   try {
-    /*const raw = storage.getString(ROOT_STATE_STORAGE_KEY)
+    /* const raw = storage.getString(ROOT_STATE_STORAGE_KEY)
     if (raw) {
       const snapshot = JSON.parse(raw)
       applySnapshot(_rootStore, snapshot)
-      restoredState = snapshot*/
+      restoredState = snapshot */
 
       const snapshot = (await storage.load(ROOT_STATE_STORAGE_KEY)) as RootStoreSnapshot | null
       if (snapshot) {
@@ -43,6 +47,7 @@ export async function setupRootStore(): Promise<{
 
   // 🚀 Start syncing and persisting just the habitStore
   persistHabitStore(_rootStore.habitStore)
+  persistSettingsStore(_rootStore.settingsStore)
   syncNotifications(_rootStore.habitStore)
 
   return { rootStore: _rootStore, restoredState }

--- a/app/models/helpers/useStores.ts
+++ b/app/models/helpers/useStores.ts
@@ -8,6 +8,9 @@ const _rootStore = RootStoreModel.create({
     habits: [],
     checkIns: [],
   },
+  settingsStore: {
+    isDarkMode: false,
+  },
 })
 
 // ✅ Shared context for app-wide store access

--- a/app/models/index.ts
+++ b/app/models/index.ts
@@ -2,6 +2,7 @@
 export * from "./RootStore"
 export * from "./HabitModel"
 export * from "./HabitStore"
+export * from "./SettingsStore"
 export * from "./helpers/useStores"
 export * from "./helpers/setupRootStore"
 export { getRootStore } from "./helpers/getRootStore" // ✅ no conflict

--- a/app/navigators/app-navigator.tsx
+++ b/app/navigators/app-navigator.tsx
@@ -8,11 +8,12 @@ import { DarkTheme, DefaultTheme, NavigationContainer } from "@react-navigation/
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { Platform, useColorScheme, View, ViewStyle } from "react-native"
+import { Platform, View, ViewStyle } from "react-native"
 import * as Screens from "app/screens"
 import Config from "../config"
 import { navigationRef, useBackButtonHandler } from "./navigation-utilities"
 import { colors } from "app/theme"
+import { useStores } from "app/models"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import MaterialIcons from "@expo/vector-icons/MaterialIcons"
 import { HomeStackParamList, SettingsStackParamList, TabParamList } from "app/navigators/types"
@@ -84,7 +85,8 @@ export interface NavigationProps
   extends Partial<React.ComponentProps<typeof NavigationContainer>> {}
 
 export const AppNavigator = observer(function AppNavigator(props: NavigationProps) {
-  const colorScheme = useColorScheme()
+  const { settingsStore } = useStores()
+  const colorScheme = settingsStore.isDarkMode ? "dark" : "light"
 
   useBackButtonHandler((routeName) => exitRoutes.includes(routeName))
 
@@ -121,7 +123,7 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
           headerShown: false,
           tabBarShowLabel: false,
           tabBarHideOnKeyboard: true,
-          tabBarStyle: $tabBarStyles,
+          tabBarStyle: $tabBarStyles(),
         })}
       >
         

--- a/app/navigators/styles.ts
+++ b/app/navigators/styles.ts
@@ -1,7 +1,7 @@
 import { colors, spacing } from "app/theme"
 import { ViewStyle } from "react-native"
 
-export const $tabBarStyles: ViewStyle = {
+export const $tabBarStyles = (): ViewStyle => ({
   position: "absolute",
   bottom: 25,
   left: 30,
@@ -16,4 +16,4 @@ export const $tabBarStyles: ViewStyle = {
   shadowOpacity: 0.25,
   shadowRadius: 3.84,
   elevation: 5,
-}
+})

--- a/app/screens/settings.tsx
+++ b/app/screens/settings.tsx
@@ -4,6 +4,7 @@ import { View, ViewStyle, TouchableOpacity } from "react-native"
 
 import { Text, Screen, Icon, Toggle, IconTypes } from "app/components"
 import layout from "app/utils/layout"
+import { useStores } from "app/models"
 
 import { SettingsScreenProps, SettingsStackParamList } from "../navigators/types"
 import { colors, spacing } from "../theme"
@@ -73,7 +74,7 @@ export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
     return (
       <Screen preset="scroll" safeAreaEdges={["top", "bottom"]} contentContainerStyle={$container}>
         <Text text="Settings" preset="subheading" size="xl" />
-        <View style={$topContainer}>
+        <View style={$topContainer()}>
           <Icon icon="avatar" />
           <View style={$userInfosContainer}>
             <View>
@@ -90,14 +91,14 @@ export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
 
         <View style={$generalContainer}>
           <Text text="General" preset="formLabel" />
-          <View style={$generalLinksContainer}>
+          <View style={$generalLinksContainer()}>
             {generalLinks.map((l, idx) => (
               <Link
                 key={`${l.id}-${l.to}`}
                 icon={l.icon}
                 title={l.title}
                 // TODO: type the to prop (path to the page)
-                handleClick={() => navigation.navigate(l.to as any)}
+                handleClick={() => l.to && navigation.navigate(l.to as any)}
                 length={generalLinks.length}
                 index={idx}
               />
@@ -107,7 +108,7 @@ export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
 
         <View style={$generalContainer}>
           <Text text="About Us" preset="formLabel" />
-          <View style={$generalLinksContainer}>
+          <View style={$generalLinksContainer()}>
             {aboutLinks.map((l, idx) => (
               <Link
                 key={`${l.id}-${l.to}`}
@@ -151,21 +152,29 @@ interface LinkProps extends GeneralLinkType {
   handleClick: () => void
 }
 
-export function Link(props: LinkProps) {
+export const Link = observer(function Link(props: LinkProps) {
   const { icon, title, length, index, handleClick } = props
+  const { settingsStore } = useStores()
+
+  const isDarkModeItem = title === "Dark Mode"
 
   return (
     <View style={{ gap: spacing.xs }}>
-      <TouchableOpacity style={$generalLink} onPress={handleClick}>
+      <TouchableOpacity
+        style={$generalLink}
+        onPress={isDarkModeItem ? undefined : handleClick}
+        accessibilityRole={isDarkModeItem ? undefined : "button"}
+      >
         <View style={$generalName}>
           <Icon icon={icon} />
           <Text text={title} />
         </View>
-        {title === "Dark Mode" ? (
+        {isDarkModeItem ? (
           <Toggle
             variant="switch"
-            // value={}
-            // onValueChange={() => setReminder(reminder ? "" : "30 minutes before")}
+            accessibilityLabel="Toggle dark mode"
+            value={settingsStore.isDarkMode}
+            onValueChange={settingsStore.setDarkMode}
             inputInnerStyle={{
               backgroundColor: colors.palette.neutral100,
             }}
@@ -177,10 +186,10 @@ export function Link(props: LinkProps) {
           <Icon icon="caretRight" />
         )}
       </TouchableOpacity>
-      {length !== (index ?? 0) + 1 && <View style={$separator} />}
+      {length !== (index ?? 0) + 1 && <View style={$separator()} />}
     </View>
   )
-}
+})
 
 const $container: ViewStyle = {
   paddingHorizontal: spacing.md,
@@ -188,7 +197,7 @@ const $container: ViewStyle = {
   paddingBottom: 70,
 }
 
-const $topContainer: ViewStyle = {
+const $topContainer = (): ViewStyle => ({
   flexDirection: "row",
   alignItems: "center",
   gap: 16,
@@ -198,7 +207,7 @@ const $topContainer: ViewStyle = {
   paddingBottom: spacing.xs,
   paddingHorizontal: spacing.md,
   maxWidth: layout.window.width * 0.95,
-}
+})
 
 const $userInfosContainer: ViewStyle = {
   flexDirection: "row",
@@ -211,12 +220,12 @@ const $generalContainer: ViewStyle = {
   gap: spacing.md,
 }
 
-const $generalLinksContainer: ViewStyle = {
+const $generalLinksContainer = (): ViewStyle => ({
   backgroundColor: colors.palette.neutral100,
   borderRadius: spacing.xs,
   padding: spacing.md,
   gap: spacing.xs,
-}
+})
 
 const $generalLink: ViewStyle = {
   flexDirection: "row",
@@ -232,8 +241,8 @@ const $generalName: ViewStyle = {
   alignItems: "center",
 }
 
-const $separator: ViewStyle = {
+const $separator = (): ViewStyle => ({
   width: "100%",
   height: 1,
   backgroundColor: colors.palette.neutral200,
-}
+})

--- a/app/theme/colors.ts
+++ b/app/theme/colors.ts
@@ -1,7 +1,5 @@
 // TODO: write documentation for colors and palette in own markdown file and add links from here
 
-import { Appearance } from "react-native"
-
 const lightPalette = {
   neutral100: "#FFFFFF",
   neutral200: "#F4F2F1",
@@ -80,54 +78,65 @@ const darkPalette = {
   overlay50: "rgba(25, 16, 21, 0.5)",
 } as const
 
-const colorScheme = Appearance.getColorScheme() ?? "light"
-const palette = colorScheme === "dark" ? darkPalette : lightPalette
+let colorScheme: "light" | "dark" = "light"
 
-export const colors = {
-  /**
-   * The palette is available to use, but prefer using the name.
-   * This is only included for rare, one-off cases. Try to use
-   * semantic names as much as possible.
-   */
-  palette,
-  /**
-   * A helper for making something see-thru.
-   */
-  transparent: "rgba(0, 0, 0, 0)",
-  /**
-   * The default text color in many components.
-   */
-  text: colorScheme === "dark" ? palette.neutral900 : palette.neutral800,
-  /**
-   * Secondary text information.
-   */
-  textDim: colorScheme === "dark" ? palette.neutral700 : palette.neutral600,
-  /**
-   * The default color of the screen background.
-   */
-  background: colorScheme === "dark" ? palette.neutral100 : palette.neutral200,
-  /**
-   * The default border color.
-   */
-  border: colorScheme === "dark" ? palette.neutral300 : palette.neutral400,
-  /**
-   * The main tinting color.
-   */
-  tint: palette.primary500,
-  /**
-   * A subtle color used for lines.
-   */
-  separator: colorScheme === "dark" ? palette.neutral300 : palette.neutral300,
-  /**
-   * Error messages.
-   */
-  error: palette.angry500,
-  /**
-   * Error Background.
-   */
-  errorBackground: palette.angry100,
-  /**
-   * Success messages
-   */
-  success: palette.success,
+const buildColors = (scheme: "light" | "dark") => {
+  const palette = scheme === "dark" ? darkPalette : lightPalette
+  return {
+    /**
+     * The palette is available to use, but prefer using the name.
+     * This is only included for rare, one-off cases. Try to use
+     * semantic names as much as possible.
+     */
+    palette,
+    /**
+     * A helper for making something see-thru.
+     */
+    transparent: "rgba(0, 0, 0, 0)",
+    /**
+     * The default text color in many components.
+     */
+    text: scheme === "dark" ? palette.neutral900 : palette.neutral800,
+    /**
+     * Secondary text information.
+     */
+    textDim: scheme === "dark" ? palette.neutral700 : palette.neutral600,
+    /**
+     * The default color of the screen background.
+     */
+    background: scheme === "dark" ? palette.neutral100 : palette.neutral200,
+    /**
+     * The default border color.
+     */
+    border: scheme === "dark" ? palette.neutral300 : palette.neutral400,
+    /**
+     * The main tinting color.
+     */
+    tint: palette.primary500,
+    /**
+     * A subtle color used for lines.
+     */
+    separator: scheme === "dark" ? palette.neutral300 : palette.neutral300,
+    /**
+     * Error messages.
+     */
+    error: palette.angry500,
+    /**
+     * Error Background.
+     */
+    errorBackground: palette.angry100,
+    /**
+     * Success messages
+     */
+    success: palette.success,
+  }
 }
+
+export let colors = buildColors(colorScheme)
+
+export const setColorScheme = (scheme: "light" | "dark") => {
+  colorScheme = scheme
+  colors = buildColors(scheme)
+}
+
+export const getColorScheme = () => colorScheme


### PR DESCRIPTION
## Summary
- allow toggling dark mode in settings with accessible switch
- persist theme preference and apply across app navigation
- expose color scheme setter and palettes for manual control

## Testing
- `npm test`
- `npm run lint` *(fails: 'TouchableOpacity' is defined but never used, Inline style errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a243e95a208331b911d700c562430d