### PR TITLE
Persist user profile in secure storage

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -19,6 +19,7 @@ import { ViewStyle, View, Platform } from "react-native"
 import Toast from "react-native-toast-message"
 import * as Notifications from "expo-notifications"
 import { persistHabitStore } from "app/models/helpers/persistHabitStore"
+import { persistUserStore } from "app/models/helpers/persistUserStore"
 import { syncNotifications } from "app/utils/syncNotifications"
 
 export const NAVIGATION_PERSISTENCE_KEY = "NAVIGATION_STATE"
@@ -72,6 +73,7 @@ const App = observer(function App(props: AppProps) {
   }) */
   const { rehydrated, rootStore } = useInitialRootStore(() => {
     persistHabitStore(rootStore.habitStore)
+    persistUserStore(rootStore.userStore)
     syncNotifications(rootStore.habitStore)
 
     if (__DEV__) console.log("✅ RootStore ready. Hiding splash in 500ms")

--- a/app/models/helpers/persistUserStore.test.ts
+++ b/app/models/helpers/persistUserStore.test.ts
@@ -1,0 +1,56 @@
+import { getSnapshot } from "mobx-state-tree"
+
+jest.mock("../../utils/secureStorage", () => ({
+  loadString: jest.fn().mockResolvedValue(null),
+  saveString: jest.fn().mockResolvedValue(true),
+  remove: jest.fn().mockResolvedValue(undefined),
+}))
+
+const secureStorage = require("../../utils/secureStorage") as jest.Mocked<
+  typeof import("../../utils/secureStorage")
+>
+const { UserStore } = require("../UserStore")
+const { persistUserStore } = require("./persistUserStore")
+
+const STORAGE_KEY = "user-store"
+
+const sampleSnapshot = {
+  fullName: "Test User",
+  email: "test@example.com",
+  bio: "",
+  twitter: "",
+  linkedin: "",
+  instagram: "",
+  facebook: "",
+  avatar: "",
+}
+
+test("loads snapshot on start and saves on change", async () => {
+  ;(secureStorage.loadString as jest.Mock).mockResolvedValue(
+    JSON.stringify(sampleSnapshot),
+  )
+  const saveStringMock = secureStorage.saveString as jest.Mock
+
+  const store = UserStore.create({})
+  await persistUserStore(store)
+
+  expect(getSnapshot(store)).toEqual(sampleSnapshot)
+
+  store.update({ fullName: "Another User" })
+  const updatedSnapshot = getSnapshot(store)
+  expect(saveStringMock).toHaveBeenLastCalledWith(
+    STORAGE_KEY,
+    JSON.stringify(updatedSnapshot),
+  )
+})
+
+test("removes user-store key on parse error", async () => {
+  ;(secureStorage.loadString as jest.Mock).mockResolvedValue("not json")
+  const removeMock = secureStorage.remove as jest.Mock
+
+  const store = UserStore.create({})
+  await persistUserStore(store)
+
+  expect(removeMock).toHaveBeenCalledWith(STORAGE_KEY)
+})
+


### PR DESCRIPTION
## Summary
- persist user store alongside habit store on app init
- test secure storage rehydration for user store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a100ddcc8331ad0bddab1830dce6