### PR TITLE
Fix statistics screen filters and progress calculations

### DIFF
--- a/app/models/HabitStore.ts
+++ b/app/models/HabitStore.ts
@@ -37,11 +37,11 @@ export const HabitStore = types
     habits: types.array(HabitModel),
     checkIns: types.optional(types.array(CheckInModel), []),
   })
-  .views((store) => ({
-    get days(): { day: string; date: string; progress: number }[] {
+  .views((store) => {
+    const getDays = (range: number): { day: string; date: string; progress: number }[] => {
       const today = new Date()
-      return Array.from({ length: 7 }).map((_, i) => {
-        const date = subDays(today, 6 - i)
+      return Array.from({ length: range }).map((_, i) => {
+        const date = subDays(today, range - 1 - i)
         const dateKey = format(date, "yyyy-MM-dd")
         const progress = store.habits.reduce((sum, habit) => {
           return habit.lastUpdated === dateKey && habit.progress > 0 ? sum + 1 : sum
@@ -52,8 +52,15 @@ export const HabitStore = types
           progress,
         }
       })
-    },
-  }))
+    }
+
+    return {
+      getDays,
+      get days() {
+        return getDays(7)
+      },
+    }
+  })
   .actions(withSetPropAction)
   .actions((store) => ({
     addHabit(


### PR DESCRIPTION
## Summary
- Support dynamic date ranges for statistics via new `getDays` helper
- Update statistics screen to use selected range and compute progress percentages correctly

## Testing
- `npm test`
- `npm run compile` *(fails: Option 'customConditions' can only be used when 'moduleResolution' is set to 'node16', 'nodenext', or 'bundler')*


------
https://chatgpt.com/codex/tasks/task_e_68a2a5ff6f7c8331a8562bab1ee3a7d3