### PR TITLE
Fix navigation from Personal Infos to Settings

### DIFF
--- a/app/screens/home.tsx
+++ b/app/screens/home.tsx
@@ -66,7 +66,11 @@ export const HomeScreen: FC<HomeScreenProps> = observer(function HomeScreen({ na
         >
           <View style={{ flexDirection: "row", alignItems: "center", gap: 20 }}>
             <TouchableOpacity
-              onPress={() => navigation.navigate("SettingsStack", { screen: "PersonalInfos" })}
+              onPress={() => {
+                const parent = navigation.getParent()
+                parent?.navigate("SettingsStack")
+                parent?.navigate("SettingsStack", { screen: "PersonalInfos" })
+              }}
             >
               <Image
                 source={


### PR DESCRIPTION
## Summary
- Ensure avatar tap navigates to Settings then Personal Infos to build proper stack history

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2a83ad9cc83319210afeb741a314f