### PR TITLE
Ensure Settings tab opens Settings screen

### DIFF
--- a/app/navigators/app-navigator.tsx
+++ b/app/navigators/app-navigator.tsx
@@ -118,11 +118,16 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
           tabBarStyle: $tabBarStyles(),
         })}
       >
-        
         {<Tab.Screen name="Statistics" component={Screens.StatisticsScreen} />}
         <Tab.Screen name="HomeStack" component={HomeStack} />
         <Tab.Screen name="CreateHabit" component={Screens.CreateHabitScreen} />
-        {<Tab.Screen name="SettingsStack" component={SettingsStack} />}
+        {
+          <Tab.Screen
+            name="SettingsStack"
+            component={SettingsStack}
+            options={{ unmountOnBlur: true }}
+          />
+        }
       </Tab.Navigator>
     </NavigationContainer>
   )

--- a/app/navigators/types.ts
+++ b/app/navigators/types.ts
@@ -3,16 +3,28 @@ import { CompositeScreenProps, NavigatorScreenParams } from "@react-navigation/n
 import { StackScreenProps } from "@react-navigation/stack"
 
 export type HomeStackParamList = {
-  Home: undefined;
-  CreateHabit: undefined;
-  CreateNewHabit: undefined;
-  EditHabit: { habitId: string };
-  Calendar: undefined;
-};
-
+  Home: undefined
+  CreateHabit: undefined
+  CreateNewHabit: undefined
+  EditHabit: { habitId: string }
+  Calendar: undefined
+}
 
 export type SettingsStackParamList = {
-  Settings: undefined
+  Settings:
+    | {
+        to?:
+          | "PersonalInfos"
+          | "Notifications"
+          | "Security"
+          | "EditPassword"
+          | "Language"
+          | "AboutUs"
+          | "Rating"
+          | "Support"
+          | "EditPersonalInfos"
+      }
+    | undefined
   PersonalInfos: undefined
   Notifications: undefined
   Security: undefined
@@ -41,6 +53,5 @@ export type SettingsScreenProps<T extends keyof SettingsStackParamList> = Compos
   BottomTabScreenProps<TabParamList, "SettingsStack">,
   StackScreenProps<SettingsStackParamList, T>
 >
-
 
 export type HomeNavProps = HomeStackScreenProps<"Home">["navigation"]

--- a/app/screens/home.tsx
+++ b/app/screens/home.tsx
@@ -68,8 +68,10 @@ export const HomeScreen: FC<HomeScreenProps> = observer(function HomeScreen({ na
             <TouchableOpacity
               onPress={() => {
                 const parent = navigation.getParent()
-                parent?.navigate("SettingsStack")
-                parent?.navigate("SettingsStack", { screen: "PersonalInfos" })
+                parent?.navigate("SettingsStack", {
+                  screen: "Settings",
+                  params: { to: "PersonalInfos" },
+                })
               }}
             >
               <Image

--- a/app/screens/settings.tsx
+++ b/app/screens/settings.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite"
-import React, { FC } from "react"
+import React, { FC, useEffect } from "react"
 import { View, ViewStyle, TouchableOpacity, Image, ImageStyle } from "react-native"
 
 import { Text, Screen, Icon, IconTypes } from "app/components"
@@ -70,8 +70,17 @@ const aboutLinks: GeneralLinkType[] = [
 ]
 
 export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
-  function SettingsScreen({ navigation }) {
+  function SettingsScreen({ navigation, route }) {
     const { userStore } = useStores()
+    const to = route.params?.to
+
+    useEffect(() => {
+      if (to) {
+        navigation.navigate(to)
+        navigation.setParams({ to: undefined })
+      }
+    }, [to, navigation])
+
     return (
       <Screen preset="scroll" safeAreaEdges={["top", "bottom"]} contentContainerStyle={$container}>
         <Text text="Settings" preset="subheading" size="xl" />


### PR DESCRIPTION
## Summary
- add optional `to` navigation param for Settings screen
- ensure avatar press opens personal info after showing Settings
- reset Settings tab state when switching away

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2abf6ec9c8331aeeef0d9c971ef05