### PR TITLE
fix: reset settings tab to root

### DIFF
--- a/app/navigators/app-navigator.tsx
+++ b/app/navigators/app-navigator.tsx
@@ -126,6 +126,12 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
             name="SettingsStack"
             component={SettingsStack}
             options={{ unmountOnBlur: true }}
+            listeners={({ navigation }) => ({
+              tabPress: (e) => {
+                e.preventDefault()
+                navigation.navigate("SettingsStack", { screen: "Settings" })
+              },
+            })}
           />
         }
       </Tab.Navigator>

--- a/app/navigators/types.ts
+++ b/app/navigators/types.ts
@@ -11,20 +11,7 @@ export type HomeStackParamList = {
 }
 
 export type SettingsStackParamList = {
-  Settings:
-    | {
-        to?:
-          | "PersonalInfos"
-          | "Notifications"
-          | "Security"
-          | "EditPassword"
-          | "Language"
-          | "AboutUs"
-          | "Rating"
-          | "Support"
-          | "EditPersonalInfos"
-      }
-    | undefined
+  Settings: undefined
   PersonalInfos: undefined
   Notifications: undefined
   Security: undefined

--- a/app/screens/home.tsx
+++ b/app/screens/home.tsx
@@ -68,10 +68,7 @@ export const HomeScreen: FC<HomeScreenProps> = observer(function HomeScreen({ na
             <TouchableOpacity
               onPress={() => {
                 const parent = navigation.getParent()
-                parent?.navigate("SettingsStack", {
-                  screen: "Settings",
-                  params: { to: "PersonalInfos" },
-                })
+                parent?.navigate("SettingsStack", { screen: "PersonalInfos" })
               }}
             >
               <Image

--- a/app/screens/settings.tsx
+++ b/app/screens/settings.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite"
-import React, { FC, useEffect } from "react"
+import React, { FC } from "react"
 import { View, ViewStyle, TouchableOpacity, Image, ImageStyle } from "react-native"
 
 import { Text, Screen, Icon, IconTypes } from "app/components"
@@ -70,16 +70,8 @@ const aboutLinks: GeneralLinkType[] = [
 ]
 
 export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
-  function SettingsScreen({ navigation, route }) {
+  function SettingsScreen({ navigation }) {
     const { userStore } = useStores()
-    const to = route.params?.to
-
-    useEffect(() => {
-      if (to) {
-        navigation.navigate(to)
-        navigation.setParams({ to: undefined })
-      }
-    }, [to, navigation])
 
     return (
       <Screen preset="scroll" safeAreaEdges={["top", "bottom"]} contentContainerStyle={$container}>


### PR DESCRIPTION
## Summary
- ensure profile avatar opens PersonalInfos without persistent params
- remove param-based redirect from Settings screen
- reset settings tab to show root screen on selection

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2af0e9648833195beab1ac0233455