### PR TITLE
chore: log storage errors

### DIFF
--- a/app/utils/secureStorage.ts
+++ b/app/utils/secureStorage.ts
@@ -3,7 +3,8 @@ import * as SecureStore from "expo-secure-store"
 export async function loadString(key: string): Promise<string | null> {
   try {
     return await SecureStore.getItemAsync(key)
-  } catch {
+  } catch (e) {
+    console.error(`Failed to load secure item for key "${key}"`, e)
     return null
   }
 }
@@ -12,7 +13,8 @@ export async function saveString(key: string, value: string): Promise<boolean> {
   try {
     await SecureStore.setItemAsync(key, value)
     return true
-  } catch {
+  } catch (e) {
+    console.error(`Failed to save secure item for key "${key}"`, e)
     return false
   }
 }
@@ -20,5 +22,7 @@ export async function saveString(key: string, value: string): Promise<boolean> {
 export async function remove(key: string): Promise<void> {
   try {
     await SecureStore.deleteItemAsync(key)
-  } catch {}
+  } catch (e) {
+    console.error(`Failed to remove secure item for key "${key}"`, e)
+  }
 }

--- a/app/utils/storage/storage.ts
+++ b/app/utils/storage/storage.ts
@@ -8,8 +8,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage"
 export async function loadString(key: string): Promise<string | null> {
   try {
     return await AsyncStorage.getItem(key)
-  } catch {
-    // not sure why this would fail... even reading the RN docs I'm unclear
+  } catch (e) {
+    console.error(`Error loading string for key "${key}"`, e)
     return null
   }
 }
@@ -24,7 +24,8 @@ export async function saveString(key: string, value: string): Promise<boolean> {
   try {
     await AsyncStorage.setItem(key, value)
     return true
-  } catch {
+  } catch (e) {
+    console.error(`Error saving string for key "${key}"`, e)
     return false
   }
 }
@@ -38,7 +39,8 @@ export async function load(key: string): Promise<unknown | null> {
   try {
     const almostThere = await AsyncStorage.getItem(key)
     return JSON.parse(almostThere ?? "")
-  } catch {
+  } catch (e) {
+    console.error(`Error loading data for key "${key}"`, e)
     return null
   }
 }
@@ -53,7 +55,8 @@ export async function save(key: string, value: unknown): Promise<boolean> {
   try {
     await AsyncStorage.setItem(key, JSON.stringify(value))
     return true
-  } catch {
+  } catch (e) {
+    console.error(`Error saving data for key "${key}"`, e)
     return false
   }
 }
@@ -66,7 +69,9 @@ export async function save(key: string, value: unknown): Promise<boolean> {
 export async function remove(key: string): Promise<void> {
   try {
     await AsyncStorage.removeItem(key)
-  } catch {}
+  } catch (e) {
+    console.error(`Error removing item for key "${key}"`, e)
+  }
 }
 
 /**
@@ -75,5 +80,7 @@ export async function remove(key: string): Promise<void> {
 export async function clear(): Promise<void> {
   try {
     await AsyncStorage.clear()
-  } catch {}
+  } catch (e) {
+    console.error("Error clearing storage", e)
+  }
 }


### PR DESCRIPTION
## Summary
- log secure storage load/save/remove errors
- report or propagate errors in AsyncStorage wrappers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65057b34483318b104f230b599d58