### PR TITLE
feat: clear user data on logout

### DIFF
--- a/app/models/UserStore.test.ts
+++ b/app/models/UserStore.test.ts
@@ -1,0 +1,39 @@
+import { getSnapshot } from "mobx-state-tree"
+
+jest.mock("../utils/secureStorage", () => ({
+  remove: jest.fn().mockResolvedValue(undefined),
+}))
+
+const secureStorage = require("../utils/secureStorage") as jest.Mocked<
+  typeof import("../utils/secureStorage")
+>
+const { UserStore, clearUserData } = require("./UserStore")
+
+const emptySnapshot = {
+  fullName: "",
+  email: "",
+  bio: "",
+  twitter: "",
+  linkedin: "",
+  instagram: "",
+  facebook: "",
+  avatar: "",
+}
+
+test("clearUserData resets store and removes secure storage", async () => {
+  const store = UserStore.create({
+    fullName: "Test",
+    email: "test@example.com",
+    bio: "bio",
+    twitter: "t",
+    linkedin: "l",
+    instagram: "i",
+    facebook: "f",
+    avatar: "a",
+  })
+
+  await clearUserData(store)
+
+  expect(getSnapshot(store)).toEqual(emptySnapshot)
+  expect(secureStorage.remove).toHaveBeenCalledWith("user-store")
+})

--- a/app/models/UserStore.ts
+++ b/app/models/UserStore.ts
@@ -1,4 +1,5 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
+import * as secureStorage from "../utils/secureStorage"
 
 export const UserStore = types
   .model("UserStore", {
@@ -22,3 +23,17 @@ export const UserStore = types
 
 export interface UserStoreType extends Instance<typeof UserStore> {}
 export interface UserStoreSnapshot extends SnapshotOut<typeof UserStore> {}
+
+export async function clearUserData(store: UserStoreType) {
+  store.update({
+    fullName: "",
+    email: "",
+    bio: "",
+    twitter: "",
+    linkedin: "",
+    instagram: "",
+    facebook: "",
+    avatar: "",
+  })
+  await secureStorage.remove("user-store")
+}

--- a/app/screens/settings.tsx
+++ b/app/screens/settings.tsx
@@ -7,7 +7,7 @@ import layout from "app/utils/layout"
 
 import { SettingsScreenProps, SettingsStackParamList } from "../navigators/types"
 import { colors, spacing } from "../theme"
-import { useStores } from "app/models"
+import { useStores, clearUserData } from "app/models"
 
 interface GeneralLinkType {
   title: string
@@ -144,6 +144,7 @@ export const SettingsScreen: FC<SettingsScreenProps<"Settings">> = observer(
             icon="logout"
             title="Logout"
             handleClick={() => {
+              clearUserData(userStore)
               if (__DEV__) console.log("logout")
             }}
             length={1}


### PR DESCRIPTION
## Summary
- add helper to wipe user store and secure storage
- clear persisted data during logout
- test clearUserData helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a65057b4588331aaba96a392141a3a