### PR TITLE
Handle empty storage values to avoid JSON parse errors

### DIFF
--- a/app/utils/storage/storage.test.ts
+++ b/app/utils/storage/storage.test.ts
@@ -13,6 +13,12 @@ test("load", async () => {
   expect(value).toEqual(JSON.parse(VALUE_STRING))
 })
 
+test("load returns null when key not found", async () => {
+  ;(AsyncStorage.getItem as jest.Mock).mockReturnValueOnce(Promise.resolve(null))
+  const value = await load("unknown")
+  expect(value).toBeNull()
+})
+
 test("loadString", async () => {
   const value = await loadString("something")
   expect(value).toEqual(VALUE_STRING)

--- a/app/utils/storage/storage.ts
+++ b/app/utils/storage/storage.ts
@@ -37,8 +37,9 @@ export async function saveString(key: string, value: string): Promise<boolean> {
  */
 export async function load(key: string): Promise<unknown | null> {
   try {
-    const almostThere = await AsyncStorage.getItem(key)
-    return JSON.parse(almostThere ?? "")
+    const json = await AsyncStorage.getItem(key)
+    if (json == null) return null
+    return JSON.parse(json)
   } catch (e) {
     console.error(`Error loading data for key "${key}"`, e)
     return null


### PR DESCRIPTION
## Summary
- prevent storage.load from parsing empty values
- cover load() null case with unit test

## Testing
- `npm run lint`
- `CI=true npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68abb9193c28833199095a1b11f83bf5